### PR TITLE
環境変数の取得方法を変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,4 +138,5 @@ resources/
 credential.yml
 
 # exclude specific directory
+log/
 !.gitkeep

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-main: log/ python_starter/config/credential.yml
+main: log/ python_starter/.env
 	poetry run dev
 
 test:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ poetry install
 ## credentialファイル作成
 
 ```bash
-cp python_starter/config/credential-sample.yml python_starter/config/credential.yml
 cp python_starter/.env.sample python_starter/.env
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ poetry install
 
 ```bash
 cp python_starter/config/credential-sample.yml python_starter/config/credential.yml
+cp python_starter/.env.sample python_starter/.env
 ```
 
 ## プログラム実行

--- a/poetry.lock
+++ b/poetry.lock
@@ -365,6 +365,21 @@ pluggy = ">=0.12,<2.0"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
+name = "python-dotenv"
+version = "1.0.0"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "python-dotenv-1.0.0.tar.gz", hash = "sha256:a8df96034aae6d2d50a4ebe8216326c61c3eb64836776504fcca410e5937a3ba"},
+    {file = "python_dotenv-1.0.0-py3-none-any.whl", hash = "sha256:f5971a9226b701070a4bf2c38c89e5a3f0d64de8debda981d1db98583009122a"},
+]
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
 name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
@@ -480,4 +495,4 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "ded03b4342082ad88a6caa8f5b3fe814056f9a5754553b25ace0c279ded0a10f"
+content-hash = "d9b9a98e814c2f591690dbf289e8473a20794d9f7111156b6d4097576735e42c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dev = "python_starter.main:main"
 python = "^3.11"
 requests = "^2.28.2"
 PyYAML = "^6.0"
+python-dotenv = "^1.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.1"

--- a/python_starter/.env.sample
+++ b/python_starter/.env.sample
@@ -1,0 +1,1 @@
+KEY=VALUE

--- a/python_starter/application_setting/my_credential.py
+++ b/python_starter/application_setting/my_credential.py
@@ -1,16 +1,9 @@
-import yaml
+import os
+from dotenv import load_dotenv
 from pathlib import Path
-from typing import Optional
 
-credential_file_path: str = (
-    f"{Path(__file__).resolve().parent.parent}/config/credential.yml"
-)
+# 環境変数のファイルパス取得
+credential_file_path: str = f"{Path(__file__).resolve().parent.parent}/.env"
 
-
-def read_credential() -> Optional[dict]:
-    """credential情報を読み込み、辞書型で返却する
-    Returns:
-        dict: credential.ymlに記載された情報
-    """
-    with open(credential_file_path) as file:
-        return yaml.safe_load(file)
+load_dotenv(credential_file_path)
+KEY = os.getenv("KEY")

--- a/python_starter/config/credential-sample.yml
+++ b/python_starter/config/credential-sample.yml
@@ -1,1 +1,0 @@
-key: "value"

--- a/python_starter/main.py
+++ b/python_starter/main.py
@@ -6,13 +6,10 @@ from typing import Optional
 # loggerを取得
 logger: Logger = mylogger.get_logger("main")
 
-# credential情報を取得
-credential: Optional[dict] = mycredential.read_credential()
-
 
 def main():
     logger.info("hello, world.")
-    print(credential)
+    print(mycredential.KEY)
 
 
 def add_one(number: int) -> int:


### PR DESCRIPTION
## 概要
環境変数の取得方法を`python-dotenv`を使った方法に修正

## 修正内容
* `poerty add python-dotenv`
* `log/`ディレクトリ全体をgit管理外にする
  * ログローテートされたファイル名が`log/app.log.2023-05-07`であるため

## 備考
