### PR TITLE
mypyの型チェック対象をパッケージとして実行する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ format:
 	poetry run black python_starter/ tests/
 
 type-check:
-	poetry run mypy python_starter/
+	poetry run mypy -p python_starter
 
 export:
 	poetry export -f requirements.txt --output requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "python-starter"
-version = "1.1.3"
+version = "1.1.4"
 description = "Template for Python project"
 authors = ["negi524 <egtnrumpbiizarre.info@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,6 @@ types-pyyaml = "^6.0.12.8"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.mypy]
+ignore_missing_imports = true


### PR DESCRIPTION
## 概要

## 修正内容
* `pyproject.toml`にmypyの設定を記載
* 対象ディレクトリをパッケージとして検査するように`-p`を付与して実行

## 備考
* https://mypy.readthedocs.io/en/stable/config_file.html#using-a-pyproject-toml
* https://mypy.readthedocs.io/en/stable/running_mypy.html
